### PR TITLE
cleaned folder air_quality_improvement_under_covid_vsualized

### DIFF
--- a/raw_data/air_quality_improvement_under_covid_vsualized/description.md
+++ b/raw_data/air_quality_improvement_under_covid_vsualized/description.md
@@ -10,7 +10,6 @@ https://github.com/ncydexter/Air-Quality-Improvement-under-COVID-Visualized
 **TODO**
 
 
-
 **Cleaning Decision**
 1. for all datasets, delete rows where more than 3 columns are missing
 


### PR DESCRIPTION
For previous 30 commits I cleaned folder _air_quality_improvement_under_covid_vsualized_
I've logged my decisions in description.md, some of them remain undecided. 
Kept six cities - beijing, shanghai, hongkong, wuhan, london, soeul. 
Deleted two cities due to lacking data cells.